### PR TITLE
✨ avoid multi-access when multi-windows opened.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,6 +106,17 @@ export function activate(context: vscode.ExtensionContext) {
 			hoverProvider
 		)
 	);
+
+	vscode.window.onDidChangeWindowState((e) => {
+		if (e.focused) {
+			storage.activate();
+		} else {
+			storage.deactivate();
+		}
+	});
+	if (vscode.window.state.focused) {
+		storage.activate();
+	}
 	if (!stateManager.get('defaultDictLoadedOrRejectedLoading')) {
 		vscode.window.showInformationMessage('Thank you for installing, do you want to load default dictionary (English into Japanese)?', 'Yes', 'No')
 			.then(async (ans) => {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -7,17 +7,21 @@ import { AbstractBatchPutOperation } from 'abstract-level';
 export class DictionaryStorage {
     private db;
 
+    /**
+     * To get data from the database, don't forget to call `activate`.
+     * 
+     * NOTE: But multiple instances access at the same time seem not to be supported. Avoid it by using `vscode.window.onDidChangeWindowState`.
+     * @param storageFolderPath the database path.
+     */
     constructor(storageFolderPath: string) {
         this.db = new Level<string, string>(path.resolve(storageFolderPath, 'db'));
-        // lazy
-        this.activate();
     }
 
-    private async activate() {
+    public async activate() {
         await this.db.open();
     }
 
-    public deactivate() {
+    public async deactivate() {
         this.db.close();
     }
 


### PR DESCRIPTION
In this PR, I added a new event to watch the window state (on focus or not).
Only the instance linking the active window connects to the database, while other instances disconnect from the database.